### PR TITLE
Extended the task to include more information

### DIFF
--- a/CI/unit_tests/interaction_models/test_ml_model.py
+++ b/CI/unit_tests/interaction_models/test_ml_model.py
@@ -61,11 +61,13 @@ class DummyTask:
     Dummy task for the test
     """
 
-    def __call__(self,
-                 observable: np.ndarray,
-                 colloid: object,
-                 colloids: list,
-                 other_colloids: list):
+    def __call__(
+        self,
+        observable: np.ndarray,
+        colloid: object,
+        colloids: list,
+        other_colloids: list,
+    ):
         """
         Dummy call method.
         """

--- a/CI/unit_tests/interaction_models/test_ml_model.py
+++ b/CI/unit_tests/interaction_models/test_ml_model.py
@@ -61,7 +61,11 @@ class DummyTask:
     Dummy task for the test
     """
 
-    def __call__(self, data):
+    def __call__(self,
+                 observable: np.ndarray,
+                 colloid: object,
+                 colloids: list,
+                 other_colloids: list):
         """
         Dummy call method.
         """

--- a/swarmrl/models/ml_model.py
+++ b/swarmrl/models/ml_model.py
@@ -89,7 +89,10 @@ class MLModel(InteractionModel):
                 feature_vector = self.observables[str(colloid.type)].compute_observable(
                     colloid, other_colloids
                 )
-                reward = self.tasks[str(colloid.type)](feature_vector)
+                reward = self.tasks[str(colloid.type)](feature_vector,
+                                                       colloid,
+                                                       colloids,
+                                                       other_colloids)
                 action_index, logit = self.models[str(colloid.type)].compute_action(
                     feature_vector=feature_vector, explore_mode=explore_mode
                 )

--- a/swarmrl/models/ml_model.py
+++ b/swarmrl/models/ml_model.py
@@ -89,10 +89,9 @@ class MLModel(InteractionModel):
                 feature_vector = self.observables[str(colloid.type)].compute_observable(
                     colloid, other_colloids
                 )
-                reward = self.tasks[str(colloid.type)](feature_vector,
-                                                       colloid,
-                                                       colloids,
-                                                       other_colloids)
+                reward = self.tasks[str(colloid.type)](
+                    feature_vector, colloid, colloids, other_colloids
+                )
                 action_index, logit = self.models[str(colloid.type)].compute_action(
                     feature_vector=feature_vector, explore_mode=explore_mode
                 )

--- a/swarmrl/tasks/searching/gradient_sensing.py
+++ b/swarmrl/tasks/searching/gradient_sensing.py
@@ -78,7 +78,11 @@ class GradientSensing(Task, ABC):
         self.source = new_source
         return ConcentrationField(self.source, self.decay_fn, self.box_size)
 
-    def __call__(self, observable: np.ndarray):
+    def __call__(self,
+                 observable: np.ndarray,
+                 colloid: object,
+                 colloids: list,
+                 other_colloids: list) -> float:
         """
         Compute the reward.
 
@@ -88,11 +92,16 @@ class GradientSensing(Task, ABC):
 
         Parameters
         ----------
-        observable : np.ndarray (dim, )
-                Position of the colloid.
-
+        observable : np.ndarray (dimension, )
+                Observable of a single colloid.
+        colloid : object
+                The colloid, the reward should be computed for.
+        colloids : list
+                A list of all colloids in the system.
+        other_colloids : list
+                A list of all other colloids in the system.
         Returns
-        -------
+        ----------
         reward : float
                 Reward for the colloid at the current state.
         """

--- a/swarmrl/tasks/searching/gradient_sensing.py
+++ b/swarmrl/tasks/searching/gradient_sensing.py
@@ -78,11 +78,13 @@ class GradientSensing(Task, ABC):
         self.source = new_source
         return ConcentrationField(self.source, self.decay_fn, self.box_size)
 
-    def __call__(self,
-                 observable: np.ndarray,
-                 colloid: object,
-                 colloids: list,
-                 other_colloids: list) -> float:
+    def __call__(
+        self,
+        observable: np.ndarray,
+        colloid: object,
+        colloids: list,
+        other_colloids: list,
+    ) -> float:
         """
         Compute the reward.
 

--- a/swarmrl/tasks/searching/gradient_sensing_vision_cone.py
+++ b/swarmrl/tasks/searching/gradient_sensing_vision_cone.py
@@ -131,7 +131,11 @@ class GradientSensingVisionCone(Task, ABC):
 
         return MultiSensing(observables=[concentration, vision_cone])
 
-    def __call__(self, observable: np.ndarray):
+    def __call__(self,
+                 observable: np.ndarray,
+                 colloid: object,
+                 colloids: list,
+                 other_colloids: list) -> float:
         """
         Compute the reward.
 
@@ -144,8 +148,14 @@ class GradientSensingVisionCone(Task, ABC):
 
         Parameters
         ----------
-        observable : np.ndarray (dim, )
-                Position of the colloid.
+        observable : np.ndarray (dimension, )
+                Observable of a single colloid.
+        colloid : object
+                The colloid, the reward should be computed for.
+        colloids : list
+                A list of all colloids in the system.
+        other_colloids : list
+                A list of all other colloids in the system.
 
         Returns
         -------

--- a/swarmrl/tasks/searching/gradient_sensing_vision_cone.py
+++ b/swarmrl/tasks/searching/gradient_sensing_vision_cone.py
@@ -131,11 +131,13 @@ class GradientSensingVisionCone(Task, ABC):
 
         return MultiSensing(observables=[concentration, vision_cone])
 
-    def __call__(self,
-                 observable: np.ndarray,
-                 colloid: object,
-                 colloids: list,
-                 other_colloids: list) -> float:
+    def __call__(
+        self,
+        observable: np.ndarray,
+        colloid: object,
+        colloids: list,
+        other_colloids: list,
+    ) -> float:
         """
         Compute the reward.
 

--- a/swarmrl/tasks/task.py
+++ b/swarmrl/tasks/task.py
@@ -9,7 +9,6 @@ compute the loss for the models to train on.
 import jax.numpy as np
 
 
-
 class Task:
     """
     Parent class for the reinforcement learning tasks.
@@ -21,11 +20,13 @@ class Task:
         """
         pass
 
-    def __call__(self,
-                 observables: np.ndarray,
-                 colloid: object,
-                 colloids: list,
-                 other_colloids: list) -> float:
+    def __call__(
+        self,
+        observables: np.ndarray,
+        colloid: object,
+        colloids: list,
+        other_colloids: list,
+    ) -> float:
         """
         Compute the reward on the whole group of particles.
 

--- a/swarmrl/tasks/task.py
+++ b/swarmrl/tasks/task.py
@@ -9,6 +9,7 @@ compute the loss for the models to train on.
 import jax.numpy as np
 
 
+
 class Task:
     """
     Parent class for the reinforcement learning tasks.
@@ -20,15 +21,24 @@ class Task:
         """
         pass
 
-    def __call__(self, observables: np.ndarray) -> float:
+    def __call__(self,
+                 observables: np.ndarray,
+                 colloid: object,
+                 colloids: list,
+                 other_colloids: list) -> float:
         """
         Compute the reward on the whole group of particles.
 
         Parameters
         ----------
-        observables : np.ndarray (dimension, )
+        observable : np.ndarray (dimension, )
                 Observable of a single colloid.
-
+        colloid : object
+                The colloid, the reward should be computed for.
+        colloids : list
+                A list of all colloids in the system.
+        other_colloids : list
+                A list of all other colloids in the system.
         Returns
         -------
         Reward : float


### PR DESCRIPTION
Added colloid, colloids, other_colloids in the task computation to have more complex rewards than just observable-dependent ones. 

`other_colloids` are computed anyway in the ML model and are mostly used in more complex tasks. Therefore they are passed in addition to the `colloids` list. 

#### Summary of additions and changes

* call function of all tasks do now take `observable, colloid, colloids, other_colloids` as an argument. 
* ml_model passes `observable, colloid, colloids, other_colloids` to the tasks 
* dummy task in the test for the ml_model takes `observable, colloid, colloids, other_colloids` as an argument. 

